### PR TITLE
MediaPlayer Couldn't open content

### DIFF
--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -38,7 +38,7 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
     static boolean active = false;
     private static Vibrator v = (Vibrator) IncomingCallModule.reactContext.getSystemService(Context.VIBRATOR_SERVICE);
     private long[] pattern = {0, 1000, 800};
-    private static MediaPlayer player = MediaPlayer.create(IncomingCallModule.reactContext, Settings.System.DEFAULT_RINGTONE_URI);
+    private static MediaPlayer player = MediaPlayer.create(IncomingCallModule.reactContext.getApplicationContext(), Settings.System.DEFAULT_RINGTONE_URI);
     private static Activity fa;
 
     @Override


### PR DESCRIPTION
fix crash on Android 10 - LG
```
MediaPlayer: Couldn't open content://0@settings/system/ringtone_cache
    java.io.FileNotFoundException: open failed: ENOENT (No such file or directory)
        at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:149)
        at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:705)
        at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1689)
        at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1505)
        at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1422)
        at android.media.MediaPlayer.attemptDataSource(MediaPlayer.java:1111)
        at android.media.MediaPlayer.setDataSource(MediaPlayer.java:1073)
        at android.media.MediaPlayer.setDataSource(MediaPlayer.java:1008)
        at android.media.MediaPlayer.create(MediaPlayer.java:914)
        at android.media.MediaPlayer.create(MediaPlayer.java:891)
        at android.media.MediaPlayer.create(MediaPlayer.java:870)
        at com.incomingcall.UnlockScreenActivity.<clinit>(UnlockScreenActivity.java:29)
        at com.incomingcall.IncomingCallModule.display(IncomingCallModule.java:42)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loop(Looper.java:214)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
        at java.lang.Thread.run(Thread.java:919)
```