### PR TITLE
Dismiss incoming call timers when accepting or rejecting a call 

### DIFF
--- a/android/src/main/java/com/incomingcall/IncomingCallModule.java
+++ b/android/src/main/java/com/incomingcall/IncomingCallModule.java
@@ -24,7 +24,6 @@ public class IncomingCallModule extends ReactContextBaseJavaModule {
 
     private static final String TAG = "RNIC:IncomingCallModule";
     private WritableMap headlessExtras;
-    private Timer t;
 
     public IncomingCallModule(ReactApplicationContext context) {
         super(context);

--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -1,6 +1,8 @@
 package com.incomingcall;
 
+import android.app.KeyguardManager;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.WindowManager;
@@ -142,9 +144,20 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
         if (!IncomingCallModule.reactContext.hasCurrentActivity()) {
             params.putBoolean("isHeadless", true);
         }
+        KeyguardManager mKeyguardManager = (KeyguardManager) getSystemService(Context.KEYGUARD_SERVICE);
+
+        if (mKeyguardManager.isDeviceLocked()) {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mKeyguardManager.requestDismissKeyguard(this, new KeyguardManager.KeyguardDismissCallback() {
+              @Override
+              public void onDismissSucceeded() {
+                super.onDismissSucceeded();
+              }
+            });
+          }
+        }
 
         sendEvent("answerCall", params);
-
         finish();
     }
 

--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -17,7 +17,6 @@ import android.provider.Settings;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-
 import android.app.Activity;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -47,7 +46,6 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
     private static MediaPlayer player = MediaPlayer.create(IncomingCallModule.reactContext.getApplicationContext(), Settings.System.DEFAULT_RINGTONE_URI);
     private static Activity fa;
     private Timer timer;
-
 
     @Override
     public void onStart() {


### PR DESCRIPTION
Hi! I checked that a timer is set when a call is dismissed after certain timeout, but is not cancelled if the call is rejected or accepted. This causes a problem when a call is received within seconds of rejecting a previous call. Two timers are running at the same time and the first can cause the call to terminate prematurely. 

Example: 

Timeout to end call: 30secs

Steps to reproduce:

- Receive a call and reject it after 25 seconds.
- Receive a second call within the next 5 seconds

The call will be finished prematurely (less than 5 secs) by the first timer set.

Please don't hesitate to contact me if you need further info.
