### PR TITLE
Fix crash reported in issue #24. Change ringtone manager

### DIFF
--- a/android/src/main/java/com/incomingcall/IncomingCallModule.java
+++ b/android/src/main/java/com/incomingcall/IncomingCallModule.java
@@ -57,6 +57,14 @@ public class IncomingCallModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void dismiss() {
+        if (UnlockScreenActivity.active) {
+            UnlockScreenActivity.dismissIncoming();
+        }
+        return;
+    }
+
     private Context getAppContext() {
         return this.reactContext.getApplicationContext();
     }

--- a/android/src/main/java/com/incomingcall/IncomingCallModule.java
+++ b/android/src/main/java/com/incomingcall/IncomingCallModule.java
@@ -50,7 +50,6 @@ public class IncomingCallModule extends ReactContextBaseJavaModule {
             i.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED +
             WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD +
             WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
-            
             i.putExtras(bundle);
             reactContext.startActivity(i);
             
@@ -59,8 +58,9 @@ public class IncomingCallModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void dismiss() {
+
         if (UnlockScreenActivity.active) {
-            UnlockScreenActivity.dismissIncoming();
+           UnlockScreenActivity.getInstance().dismissIncoming();
         }
         return;
     }

--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -37,7 +37,6 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
     private String uuid = "";
     static boolean active = false;
     private static Vibrator vibrator;
-    private AudioManager am;
     private static Ringtone ringtone;
     private static Activity fa;
     private Timer timer;
@@ -70,8 +69,6 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
         super.onCreate(savedInstanceState);
 
         fa = this;
-        am = (AudioManager)getSystemService(Context.AUDIO_SERVICE);
-
         setContentView(R.layout.activity_call_incoming);
 
         tvName = findViewById(R.id.tvName);

--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -129,8 +129,7 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
         rejectCallBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                vibrator.cancel();
-                ringtone.stop();
+                stopRinging();
                 dismissDialing();
             }
         });

--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -1,15 +1,17 @@
 package com.incomingcall;
 
 import android.app.KeyguardManager;
-import android.content.Intent;
+import android.media.AudioManager;
+import android.media.Ringtone;
+import android.media.RingtoneManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.VibrationEffect;
 import android.util.Log;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.view.View;
-import android.net.Uri;
 import android.os.Vibrator;
 import android.content.Context;
 import android.media.MediaPlayer;
@@ -17,18 +19,12 @@ import android.provider.Settings;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-
 import android.app.Activity;
-
 import androidx.appcompat.app.AppCompatActivity;
-import android.app.ActivityManager;
-import android.app.ActivityManager.RunningAppProcessInfo;
 
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import com.squareup.picasso.Picasso;
@@ -42,9 +38,9 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
     private Integer timeout = 0;
     private String uuid = "";
     static boolean active = false;
-    private static Vibrator v = (Vibrator) IncomingCallModule.reactContext.getSystemService(Context.VIBRATOR_SERVICE);
-    private long[] pattern = {0, 1000, 800};
-    private static MediaPlayer player = MediaPlayer.create(IncomingCallModule.reactContext, Settings.System.DEFAULT_RINGTONE_URI);
+    private static Vibrator vibrator;
+    private AudioManager am;
+    private static Ringtone ringtone;
     private static Activity fa;
     private Timer timer;
 
@@ -76,6 +72,7 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
         super.onCreate(savedInstanceState);
 
         fa = this;
+        am = (AudioManager)getSystemService(Context.AUDIO_SERVICE);
 
         setContentView(R.layout.activity_call_incoming);
 
@@ -111,17 +108,16 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
                 | WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED | WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
 
-        v.vibrate(pattern, 0);
-        player.start();
+        ringPhone();
+
 
         AnimateImage acceptCallBtn = findViewById(R.id.ivAcceptCall);
         acceptCallBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 try {
-                    v.cancel();
-                    player.stop();
-                    player.prepareAsync();
+                    vibrator.cancel();
+                    ringtone.stop();
                     acceptDialing();
                 } catch (Exception e) {
                     WritableMap params = Arguments.createMap();
@@ -136,9 +132,8 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
         rejectCallBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                v.cancel();
-                player.stop();
-                player.prepareAsync();
+                vibrator.cancel();
+                ringtone.stop();
                 dismissDialing();
             }
         });
@@ -151,13 +146,31 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
     }
 
     public static void dismissIncoming() {
-        v.cancel();
-        player.stop();
-        player.prepareAsync();
+        vibrator.cancel();
+        ringtone.stop();
         fa.finish();
     }
 
-    private void acceptDialing() {
+    private void ringPhone(){
+      long[] pattern = {0, 1000, 800};
+      vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+      int ringerMode = ((AudioManager) getSystemService(Context.AUDIO_SERVICE)).getRingerMode();
+      if(ringerMode == AudioManager.RINGER_MODE_SILENT) return;
+
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+        VibrationEffect vibe = VibrationEffect.createWaveform(pattern, 2);
+        vibrator.vibrate(vibe);
+      }else{
+        vibrator.vibrate(pattern, 0);
+      }
+      if(ringerMode == AudioManager.RINGER_MODE_VIBRATE) return;
+
+      ringtone = RingtoneManager.getRingtone(this, RingtoneManager.getActualDefaultRingtoneUri(getApplicationContext(), RingtoneManager.TYPE_RINGTONE));
+      ringtone.play();
+    }
+
+
+  private void acceptDialing() {
         WritableMap params = Arguments.createMap();
         params.putBoolean("accept", true);
         params.putString("uuid", uuid);

--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -40,14 +40,20 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
     private static Ringtone ringtone;
     private static Activity fa;
     private Timer timer;
+    static UnlockScreenActivity instance;
+
+
+    public static UnlockScreenActivity getInstance() {
+      return instance;
+    }
 
 
     @Override
     public void onStart() {
         super.onStart();
         if (this.timeout > 0) {
-              this.timer = new Timer();
-              this.timer.schedule(new TimerTask() {
+              timer = new Timer();
+              timer.schedule(new TimerTask() {
                 @Override
                 public void run() {
                     // this code will be executed after timeout seconds
@@ -56,6 +62,7 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
             }, timeout);
         }
         active = true;
+        instance = this;
     }
 
     @Override
@@ -166,7 +173,7 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
         vibrator.cancel();
       }
       int ringerMode = ((AudioManager) getSystemService(Context.AUDIO_SERVICE)).getRingerMode();
-      if(ringerMode == AudioManager.RINGER_MODE_SILENT) return;
+      if(ringerMode != AudioManager.RINGER_MODE_NORMAL) return;
       ringtone.stop();
     }
 


### PR DESCRIPTION
- RCT dismiss call crash fixed. Fixes #24
- Use RingtoneManager instead of AudioManager for playing the ringtone. Calls use now ringtone volume instead of media volume. Avoid ring sound if the device is in silent / do not disturb mode.  