### PR TITLE
Check if timer already exists before scheduling

### DIFF
--- a/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
+++ b/android/src/main/java/com/incomingcall/UnlockScreenActivity.java
@@ -52,7 +52,7 @@ public class UnlockScreenActivity extends AppCompatActivity implements UnlockScr
     @Override
     public void onStart() {
         super.onStart();
-        if (this.timeout > 0) {
+        if (this.timeout > 0 && this.timer == null) {
               this.timer = new Timer();
               this.timer.schedule(new TimerTask() {
                 @Override


### PR DESCRIPTION
Fixes an issue where two timers are created if the incoming call screen is triggered when the app is in the background and the screen is locked, and the first one is not being cancelled when answering the call, resulting in the call being dropped by it.

The issue is caused by the `onStart` lifecycle method being called twice due to the screen being turned on. This is explained well in this [StackOverflow answer](https://stackoverflow.com/a/25474853/2468126).